### PR TITLE
Use grep on Gemfile.lock to determine if webpack-rails gem is present.

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -1,6 +1,7 @@
 #!/bin/sh
 
-if [ -f "$1/config/webpack.config.js" ]; then
+if grep -q "webpack-rails" $1/Gemfile.lock
+then
   echo "Webpack"
   exit 0
 else


### PR DESCRIPTION
This way if someone changed `config.webpack.config_file` on their `config/application.rb` this won't break.
